### PR TITLE
Update landing page schema for images

### DIFF
--- a/src/components/InsetImage.astro
+++ b/src/components/InsetImage.astro
@@ -1,0 +1,31 @@
+---
+export interface Props {
+  src: string | { src: string };
+  alt?: string;
+}
+const { src, alt = '' } = Astro.props;
+---
+<figure class="inset-image-wrapper">
+  <img
+    src={typeof src === 'string' ? src : src.src}
+    alt={alt}
+    class="inset-image"
+    loading="lazy"
+    decoding="async"
+  />
+</figure>
+<style>
+.inset-image-wrapper {
+  margin: 2rem auto;
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+}
+
+.inset-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import LetterCanvas from '../components/LetterCanvas.astro';
 import Layout from '../layouts/Layout.astro';
 import FullBleedImage from '../components/FullBleedImage.astro';
+import InsetImage from '../components/InsetImage.astro';
 import familyUrl from '../assets/family.webp';
 import { getClient, urlFor } from '../lib/sanityClient';
 import { landingPageQuery } from '../lib/queries';
@@ -49,6 +50,19 @@ const components = landingPageData?.components || defaultComponents;
           alt={component.alt || 'Family'} 
         />
       );
+    }
+    
+    if ((component as any)._type === 'insetImage') {
+      // @ts-ignore – insetImage type is not yet present in generated definitions
+      const comp = component as any;
+      const hasValidImage = comp.image?.asset?._ref && 
+                           comp.image.asset._ref.length > 0;
+
+      const imageSrc = hasValidImage
+        ? urlFor(comp.image).width(1200).fit('max').url()
+        : familyUrl.src;
+
+      return <InsetImage src={imageSrc} alt={comp.alt || 'Image'} />;
     }
     
     return null;

--- a/studio/schemaTypes/landingPage.ts
+++ b/studio/schemaTypes/landingPage.ts
@@ -81,6 +81,44 @@ export default {
             },
           },
         },
+        {
+          type: 'object',
+          name: 'insetImage',
+          title: 'Inset Image',
+          icon: FiHome,
+          fields: [
+            {
+              name: 'image',
+              type: 'image',
+              title: 'Image',
+              description: 'Inset image displayed within page content width',
+              validation: (Rule: Rule) => Rule.required(),
+              options: {
+                hotspot: true,
+              },
+            },
+            {
+              name: 'alt',
+              type: 'string',
+              title: 'Alt Text',
+              description: 'Alternative text for accessibility',
+              validation: (Rule: Rule) => Rule.required(),
+            },
+          ],
+          preview: {
+            select: {
+              media: 'image',
+              title: 'alt',
+            },
+            prepare(value: { media: any; title: string }) {
+              return {
+                title: 'Inset Image',
+                subtitle: value.title || 'No alt text',
+                media: value.media,
+              }
+            },
+          },
+        },
       ],
       validation: (Rule: Rule) =>
         Rule.custom((components: any[]) => {


### PR DESCRIPTION
Add 'Inset Image' component to landing page schema and implement its rendering.

This provides editors with a new option to include images constrained to the content column, distinct from full-bleed images.